### PR TITLE
Refactor enforcement to declarative net request rules

### DIFF
--- a/CHROME_WEB_STORE.md
+++ b/CHROME_WEB_STORE.md
@@ -15,17 +15,20 @@ Upload the generated archive at `dist/lab-policy-whitelist-chrome-web-store.zip`
 
 - The extension enforces whitelist-only browsing on managed/shared lab machines.
 - It stores local admin and student/session state in `chrome.storage.local`.
-- It redirects blocked navigations to the bundled `blocked.html` page.
+- It enforces browsing policy with Manifest V3 `declarativeNetRequest` dynamic rules generated from the current whitelist.
+- Blocked navigations are redirected to the bundled `blocked.html` page.
 - It can log visit metadata and ChatGPT prompts to Firebase/GA only when valid production configuration is provided in `config.js`.
 - Heartbeat and uninstall callbacks are disabled automatically when `BACKEND_BASE` is blank.
 
 ## Permission justification
 
 - `storage`: saves whitelist rules, device ID, login state, PC code, and cached class data.
-- `tabs`: redirects blocked tabs and reads current tab metadata for logging.
-- `webNavigation`: evaluates top-level navigations before the destination page loads.
+- `activeTab`: opens the floating class-code panel only for the tab the user explicitly clicks from the toolbar.
+- `declarativeNetRequest`: enforces the whitelist using generated allow and redirect rules instead of request-time script logic.
+- `scripting`: injects the floating class-code panel into the current active tab on demand.
+- `tabs`: reads current tab metadata for logging and supports action-button behavior on the active tab.
 - `alarms`: sends periodic heartbeat pings when a backend is configured.
-- `<all_urls>`: required because the policy engine and the floating class-code panel operate across arbitrary sites.
+- `<all_urls>`: required because whitelist rules may allow arbitrary destinations and the default DNR rule redirects all other web navigations.
 
 ## Privacy disclosure draft
 

--- a/background.js
+++ b/background.js
@@ -3,6 +3,8 @@
 try { importScripts('config.js'); } catch (e) {}
 // Using Firebase REST only for Firestore writes (no SDK loaded)
 const MAX_LOGS = 10000;
+const BLOCK_ALL_RULE_ID = 1;
+const ALLOW_RULE_ID_START = 1000;
 // Load CONFIG if available (from config.js)
 const HEARTBEAT_MINUTES = (self.CONFIG && self.CONFIG.HEARTBEAT_MINUTES) || 1;
 const BACKEND_BASE = (self.CONFIG && self.CONFIG.BACKEND_BASE) || "";
@@ -27,6 +29,89 @@ function withRequiredRules(lines = []) {
   }
 
   return Array.from(new Set(normalized));
+}
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function patternToRegex(rule) {
+  const pattern = String(rule || '').trim();
+  if (!pattern) return null;
+
+  if (/^https?:\/\//.test(pattern)) {
+    return `^${escapeRegex(pattern)}`;
+  }
+
+  if (pattern.startsWith('*.')) {
+    const base = pattern.slice(2);
+    if (!base) return null;
+    return `^https?:\\/\\/([^/?#]+\\.)*${escapeRegex(base)}([/:?#]|$)`;
+  }
+
+  return `^https?:\\/\\/[^/?#]*${escapeRegex(pattern)}[^/?#]*([/:?#]|$)`;
+}
+
+function buildDynamicRules(whitelist) {
+  const rules = [];
+  let nextRuleId = ALLOW_RULE_ID_START;
+
+  for (const rule of whitelist) {
+    const regexFilter = patternToRegex(rule);
+    if (!regexFilter) continue;
+
+    rules.push({
+      id: nextRuleId,
+      priority: 2,
+      action: { type: 'allow' },
+      condition: {
+        regexFilter,
+        resourceTypes: ['main_frame']
+      }
+    });
+    nextRuleId += 1;
+  }
+
+  rules.push({
+    id: BLOCK_ALL_RULE_ID,
+    priority: 1,
+    action: {
+      type: 'redirect',
+      redirect: {
+        regexSubstitution: `${chrome.runtime.getURL('blocked.html')}#orig=\\0`
+      }
+    },
+    condition: {
+      regexFilter: '^(https?://.+)$',
+      resourceTypes: ['main_frame']
+    }
+  });
+
+  return rules;
+}
+
+async function syncBlockingRules() {
+  const whitelist = withRequiredRules(await getCombinedWhitelist());
+  const rules = buildDynamicRules(whitelist);
+  const { dnrRuleIds = [] } = await chrome.storage.local.get('dnrRuleIds');
+
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: dnrRuleIds,
+    addRules: rules
+  });
+
+  await chrome.storage.local.set({
+    dnrRuleIds: rules.map((rule) => rule.id),
+    dnrLastSync: {
+      at: Date.now(),
+      whitelistSize: whitelist.length
+    }
+  });
+
+  console.log('[LabPolicy] declarativeNetRequest rules synced', {
+    whitelistSize: whitelist.length,
+    ruleCount: rules.length
+  });
 }
 
 // Generate or fetch persistent device ID
@@ -303,11 +388,68 @@ chrome.runtime.onInstalled.addListener(async () => {
 
   // Create repeating heartbeat alarm
   chrome.alarms.create("heartbeat", { periodInMinutes: HEARTBEAT_MINUTES });
+  await syncBlockingRules();
 });
 
 // On browser startup
 chrome.runtime.onStartup.addListener(() => {
   console.log('[LabPolicy] service worker startup');
+  syncBlockingRules().catch((error) => {
+    console.warn('[LabPolicy] failed to sync rules on startup', error);
+  });
+});
+
+function isHttpUrl(url = '') {
+  return /^https?:\/\//.test(url);
+}
+
+function isBlockedPageUrl(url = '') {
+  return url.startsWith(chrome.runtime.getURL('blocked.html'));
+}
+
+async function togglePanelInTab(tab) {
+  if (!tab?.id || !tab.url) return;
+
+  if (isBlockedPageUrl(tab.url)) {
+    await chrome.tabs.sendMessage(tab.id, { type: 'toggleFabPanel' });
+    return;
+  }
+
+  if (!isHttpUrl(tab.url)) {
+    console.log('[LabPolicy] toolbar click ignored for unsupported tab', tab.url);
+    return;
+  }
+
+  try {
+    await chrome.tabs.sendMessage(tab.id, { type: 'toggleFabPanel' });
+  } catch (error) {
+    await chrome.scripting.insertCSS({
+      target: { tabId: tab.id },
+      files: ['content.css']
+    });
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['content.js']
+    });
+    await chrome.tabs.sendMessage(tab.id, { type: 'toggleFabPanel' });
+  }
+}
+
+chrome.action.onClicked.addListener(async (tab) => {
+  try {
+    await togglePanelInTab(tab);
+  } catch (error) {
+    console.warn('[LabPolicy] failed to toggle toolbar panel', error);
+  }
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local') return;
+  if (!changes.whitelist && !changes.studentInfo && !changes.classWishlistCache) return;
+
+  syncBlockingRules().catch((error) => {
+    console.warn('[LabPolicy] failed to sync rules after storage change', error);
+  });
 });
 
 // Heartbeat on alarm
@@ -396,37 +538,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return true; // keep channel open for async reply
 });
 
-// Match URL against whitelist patterns
-function isAllowed(url, whitelist) {
-  try {
-    const u = new URL(url);
-    for (const rule of whitelist) {
-      const pattern = rule.trim();
-      if (!pattern) continue;
-
-      // Exact domain match
-      if (u.hostname === pattern) return true;
-
-      // Subdomain wildcard (*.example.com)
-      if (pattern.startsWith("*.")) {
-        const base = pattern.slice(2);
-        if (u.hostname === base || u.hostname.endsWith("." + base)) {
-          return true;
-        }
-      }
-
-      // Prefix match (full URL starts with)
-      if (url.startsWith(pattern)) return true;
-
-      // Plain domain contains
-      if (u.hostname.includes(pattern)) return true;
-    }
-  } catch (e) {
-    console.warn("Bad URL:", url);
-  }
-  return false;
-}
-
 // Log visit
 async function logVisit(url, title, tabId, allowed) {
   const timestamp = new Date().toISOString();
@@ -468,44 +579,12 @@ async function logVisit(url, title, tabId, allowed) {
 }
 
 
-// Handle navigation
-chrome.webNavigation.onBeforeNavigate.addListener(async (details) => {
-  if (details.frameId !== 0) return; // only main-frame
-
-  // Ignore navigation to the extension's own URLs and the new tab page
-  if (details.url.startsWith(chrome.runtime.getURL('')) || details.url === "chrome://new-tab-page-third-party/") {
-    return;
-  }
-
-  console.log('[LabPolicy] onBeforeNavigate', details.url);
-  const whitelist = await getCombinedWhitelist();
-  const allowed = isAllowed(details.url, whitelist);
-
-  if (!allowed) {
-    chrome.tabs.update(details.tabId, {
-      url: chrome.runtime.getURL("blocked.html") + "?orig=" + encodeURIComponent(details.url)
-    });
-  }
-
-  chrome.tabs.get(details.tabId, (tab) => {
-    const title = tab?.title || "Untitled";
-    console.log('[LabPolicy] logging visit', { url: details.url, allowed });
-    logVisit(details.url, title, details.tabId, allowed);
-  });
-});
-
-// Fallback: also listen to tab updates when a page completes loading
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status !== 'complete' || !tab.url) return;
   if (tab.url.startsWith(chrome.runtime.getURL(''))) return;
   if (tab.url.startsWith('chrome://')) return;
   try {
     console.log('[LabPolicy] tabs.onUpdated complete', tab.url);
-    const whitelist = await getCombinedWhitelist();
-    const allowed = isAllowed(tab.url, whitelist);
-    if (!allowed) {
-      chrome.tabs.update(tabId, { url: chrome.runtime.getURL('blocked.html') + '?orig=' + encodeURIComponent(tab.url) });
-    }
-    logVisit(tab.url, tab.title || 'Untitled', tabId, allowed);
+    logVisit(tab.url, tab.title || 'Untitled', tabId, true);
   } catch (e) {}
 });

--- a/blocked.js
+++ b/blocked.js
@@ -1,10 +1,17 @@
 // blocked.js
 document.addEventListener("DOMContentLoaded", () => {
   const params = new URLSearchParams(location.search);
-  const orig = params.get("orig");
+  const hashParams = new URLSearchParams(location.hash.replace(/^#/, ""));
+  const orig = params.get("orig") || hashParams.get("orig");
   if (orig) {
     const el = document.getElementById("orig");
-    const decodedUrl = decodeURIComponent(orig);
+    const decodedUrl = (() => {
+      try {
+        return decodeURIComponent(orig);
+      } catch (error) {
+        return orig;
+      }
+    })();
     const label = document.createElement("strong");
     label.textContent = "Attempted URL:";
     const link = document.createElement("a");

--- a/chatgpt.js
+++ b/chatgpt.js
@@ -1,0 +1,105 @@
+if (window.location.origin.startsWith('https://chatgpt.com') && !window.__labPolicyChatGptLoggerInitialized) {
+  window.__labPolicyChatGptLoggerInitialized = true;
+
+  const SPOKEN_GRAMMAR_PREFIX = [
+    'First answer the user\'s actual question clearly and helpfully.',
+    'Then check the user text only for spoken English grammar.',
+    'Ignore capitalization, punctuation, and formatting issues.',
+    'Treat it as spoken English practice.',
+    'Reply in this order:',
+    '1. Direct answer to the user\'s question.',
+    '2. Corrected spoken-English version of the user text.',
+    '3. Short explanation of the spoken grammar mistakes.',
+    '',
+    'User text:'
+  ].join('\n');
+
+  let lastLoggedPrompt = '';
+  let lastLoggedAt = 0;
+
+  function readComposerPrompt() {
+    return document.getElementById('prompt-textarea')?.innerText?.trim() || '';
+  }
+
+  function writeComposerPrompt(prompt) {
+    const promptEl = document.getElementById('prompt-textarea');
+    if (!promptEl) return;
+
+    promptEl.innerHTML = '';
+    const paragraph = document.createElement('p');
+    paragraph.textContent = prompt;
+    promptEl.appendChild(paragraph);
+    promptEl.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertText',
+      data: prompt,
+    }));
+  }
+
+  function buildGrammarPrompt(userPrompt) {
+    return `${SPOKEN_GRAMMAR_PREFIX}\n${userPrompt}`;
+  }
+
+  function preparePromptForGrammarCheck() {
+    const userPrompt = readComposerPrompt();
+    if (!userPrompt) {
+      console.log('[site-blocker] ChatGPT prompt injection skipped: empty prompt');
+      return '';
+    }
+
+    if (userPrompt.startsWith(SPOKEN_GRAMMAR_PREFIX)) {
+      console.log('[site-blocker] ChatGPT prompt already contains spoken grammar prefix');
+      return userPrompt.slice(SPOKEN_GRAMMAR_PREFIX.length).trim();
+    }
+
+    const injectedPrompt = buildGrammarPrompt(userPrompt);
+    writeComposerPrompt(injectedPrompt);
+    console.log('[site-blocker] ChatGPT prompt injection applied', {
+      originalPrompt: userPrompt,
+      injectedPrompt,
+    });
+    return userPrompt;
+  }
+
+  async function logPrompt(prompt) {
+    if (!prompt) {
+      console.log('[site-blocker] ChatGPT prompt logging skipped: empty prompt');
+      return;
+    }
+
+    const now = Date.now();
+    if (prompt === lastLoggedPrompt && now - lastLoggedAt < 3000) {
+      console.log('[site-blocker] ChatGPT prompt logging skipped: duplicate submit', { prompt });
+      return;
+    }
+
+    lastLoggedPrompt = prompt;
+    lastLoggedAt = now;
+
+    try {
+      console.log('[site-blocker] ChatGPT prompt detected', { prompt });
+      const response = await chrome.runtime.sendMessage({
+        type: 'logChatGptPrompt',
+        prompt,
+      });
+      console.log('[site-blocker] ChatGPT prompt logged', response);
+    } catch (error) {
+      console.warn('[site-blocker] failed to log ChatGPT prompt', error);
+    }
+  }
+
+  document.addEventListener('click', (event) => {
+    const submitButton = event.target.closest('#composer-submit-button');
+    if (!submitButton) return;
+    console.log('[site-blocker] ChatGPT submit button clicked');
+    logPrompt(preparePromptForGrammarCheck());
+  }, true);
+
+  document.addEventListener('keydown', (event) => {
+    const promptEl = event.target.closest('#prompt-textarea');
+    if (!promptEl) return;
+    if (event.key !== 'Enter' || event.shiftKey || event.isComposing) return;
+    console.log('[site-blocker] ChatGPT prompt submitted with Enter key');
+    logPrompt(preparePromptForGrammarCheck());
+  }, true);
+}

--- a/content.js
+++ b/content.js
@@ -1,18 +1,31 @@
-// Script only runs on http/https pages
+function bootstrapFab() {
+  if (!document.body) {
+    const observer = new MutationObserver(() => {
+      if (document.body) {
+        observer.disconnect();
+        initFab();
+      }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    return;
+  }
 
-if (!document.body) {
-  const observer = new MutationObserver(() => {
-    if (document.body) {
-      observer.disconnect();
-      initFab();
-      initChatGptPromptLogger();
-    }
-  });
-  observer.observe(document.documentElement, { childList: true, subtree: true });
-} else {
   initFab();
-  initChatGptPromptLogger();
 }
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || message.type !== 'toggleFabPanel') return;
+
+  bootstrapFab();
+  const panel = document.getElementById('labClassPanel');
+  if (panel) {
+    panel.classList.toggle('open');
+  }
+
+  sendResponse({ success: true });
+});
+
+bootstrapFab();
 
 function initFab() {
   if (document.getElementById('labClassFab')) return;
@@ -236,112 +249,4 @@ function initFab() {
   chrome.storage.onChanged.addListener((changes) => {
     if (changes.studentInfo || changes.pcCode || changes.labClassFabPosition) updateDisplay();
   });
-}
-
-function initChatGptPromptLogger() {
-  if (window.location.origin !== 'https://chatgpt.com') return;
-  if (window.__labPolicyChatGptLoggerInitialized) return;
-  window.__labPolicyChatGptLoggerInitialized = true;
-
-  const SPOKEN_GRAMMAR_PREFIX = [
-    'First answer the user\'s actual question clearly and helpfully.',
-    'Then check the user text only for spoken English grammar.',
-    'Ignore capitalization, punctuation, and formatting issues.',
-    'Treat it as spoken English practice.',
-    'Reply in this order:',
-    '1. Direct answer to the user\'s question.',
-    '2. Corrected spoken-English version of the user text.',
-    '3. Short explanation of the spoken grammar mistakes.',
-    '',
-    'User text:'
-  ].join('\n');
-
-  let lastLoggedPrompt = '';
-  let lastLoggedAt = 0;
-
-  function readComposerPrompt() {
-    return document.getElementById('prompt-textarea')?.innerText?.trim() || '';
-  }
-
-  function writeComposerPrompt(prompt) {
-    const promptEl = document.getElementById('prompt-textarea');
-    if (!promptEl) return;
-
-    promptEl.innerHTML = '';
-    const paragraph = document.createElement('p');
-    paragraph.textContent = prompt;
-    promptEl.appendChild(paragraph);
-    promptEl.dispatchEvent(new InputEvent('input', {
-      bubbles: true,
-      inputType: 'insertText',
-      data: prompt,
-    }));
-  }
-
-  function buildGrammarPrompt(userPrompt) {
-    return `${SPOKEN_GRAMMAR_PREFIX}\n${userPrompt}`;
-  }
-
-  function preparePromptForGrammarCheck() {
-    const userPrompt = readComposerPrompt();
-    if (!userPrompt) {
-      console.log('[site-blocker] ChatGPT prompt injection skipped: empty prompt');
-      return '';
-    }
-
-    if (userPrompt.startsWith(SPOKEN_GRAMMAR_PREFIX)) {
-      console.log('[site-blocker] ChatGPT prompt already contains spoken grammar prefix');
-      return userPrompt.slice(SPOKEN_GRAMMAR_PREFIX.length).trim();
-    }
-
-    const injectedPrompt = buildGrammarPrompt(userPrompt);
-    writeComposerPrompt(injectedPrompt);
-    console.log('[site-blocker] ChatGPT prompt injection applied', {
-      originalPrompt: userPrompt,
-      injectedPrompt,
-    });
-    return userPrompt;
-  }
-
-  async function logPrompt(prompt) {
-    if (!prompt) {
-      console.log('[site-blocker] ChatGPT prompt logging skipped: empty prompt');
-      return;
-    }
-
-    const now = Date.now();
-    if (prompt === lastLoggedPrompt && now - lastLoggedAt < 3000) {
-      console.log('[site-blocker] ChatGPT prompt logging skipped: duplicate submit', { prompt });
-      return;
-    }
-
-    lastLoggedPrompt = prompt;
-    lastLoggedAt = now;
-
-    try {
-      console.log('[site-blocker] ChatGPT prompt detected', { prompt });
-      const response = await chrome.runtime.sendMessage({
-        type: 'logChatGptPrompt',
-        prompt,
-      });
-      console.log('[site-blocker] ChatGPT prompt logged', response);
-    } catch (error) {
-      console.warn('[site-blocker] failed to log ChatGPT prompt', error);
-    }
-  }
-
-  document.addEventListener('click', (event) => {
-    const submitButton = event.target.closest('#composer-submit-button');
-    if (!submitButton) return;
-    console.log('[site-blocker] ChatGPT submit button clicked');
-    logPrompt(preparePromptForGrammarCheck());
-  }, true);
-
-  document.addEventListener('keydown', (event) => {
-    const promptEl = event.target.closest('#prompt-textarea');
-    if (!promptEl) return;
-    if (event.key !== 'Enter' || event.shiftKey || event.isComposing) return;
-    console.log('[site-blocker] ChatGPT prompt submitted with Enter key');
-    logPrompt(preparePromptForGrammarCheck());
-  }, true);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,9 +10,11 @@
     "128": "icons/icon128.png"
   },
   "permissions": [
+    "activeTab",
+    "declarativeNetRequest",
     "storage",
+    "scripting",
     "tabs",
-    "webNavigation",
     "alarms"
   ],
   "host_permissions": [
@@ -36,11 +38,9 @@
   "content_scripts": [
     {
       "matches": [
-        "http://*/*",
-        "https://*/*"
+        "https://chatgpt.com/*"
       ],
-      "js": ["content.js"],
-      "css": ["content.css"],
+      "js": ["chatgpt.js"],
       "run_at": "document_end",
       "all_frames": false
     }


### PR DESCRIPTION
- Summary
  - switch the blocking logic to Manifest V3 declarativeNetRequest dynamic allow/redirect rules plus rule-sync helpers and logging, keeping heartbeat/storage hooks intact
  - limit the floating panel injection/toolbar action to the active tab and move the ChatGPT prompt behavior into a dedicated `chatgpt.js` content script with its own `activeTab` permissions
  - update metadata (permissions, Chrome Web Store guidance, new privacy policy) to reflect the new DNR-powered model and reduced content-script scope
- Testing
  - Not run (not requested)